### PR TITLE
determine paths to call nnet_model.py

### DIFF
--- a/kaldi_starter.py
+++ b/kaldi_starter.py
@@ -5,6 +5,7 @@ import multiprocessing as mp
 import time
 import argparse
 import logging
+import sys
 
 logging.basicConfig(
     level=logging.INFO,
@@ -17,13 +18,11 @@ logger = logging.getLogger(__name__)
 def start_kaldi(server, input, output, controlChannel, speaker, language):
     if language == 'German':
         model = 'kaldi_tuda_de_nnet3_chain2.yaml'
-        kaldiDir = 'kms_env/bin/python3 nnet3_model.py -m 0 -e -t -y models/%s --redis-server=%s --redis-audio=%s --redis-channel=%s --redis-control=%s -s="%s" -fpc 190' % (model, server, input, output, controlChannel, speaker)
+        kaldiDir = f'{sys.executable} {os.getcwd()}/kaldi-model-server/nnet3_model.py -m 0 -e -t -y models/%s --redis-server=%s --redis-audio=%s --redis-channel=%s --redis-control=%s -s="%s" -fpc 190' % (model, server, input, output, controlChannel, speaker)
     else:
         onlineConf = 'en_160k_nnet3chain_tdnn1f_2048_sp_bi/conf/online.conf'
         model = 'en_160k_nnet3chain_tdnn1f_2048_sp_bi.yaml'
-        kaldiDir = 'kms_env/bin/python3 nnet3_model.py -m 0 -e -t -o models/%s -y models/%s --redis-server=%s --redis-audio=%s --redis-channel=%s --redis-control=%s -s="%s" -fpc 190' % (onlineConf, model, server, input, output, controlChannel, speaker)
-    chDir = './kaldi-model-server'
-    os.chdir(chDir)
+        kaldiDir = f'{sys.executable} {os.getcwd()}/kaldi-model-server/nnet3_model.py -m 0 -e -t -o models/%s -y models/%s --redis-server=%s --redis-audio=%s --redis-channel=%s --redis-control=%s -s="%s" -fpc 190' % (onlineConf, model, server, input, output, controlChannel, speaker)
     os.system(kaldiDir)
 
 


### PR DESCRIPTION
This patch suggests a way to determine the path of nnet3_model.py
to be able to test it more easily with a different setup.